### PR TITLE
Better way of locating the esp32-camera dependency in the cmake build script

### DIFF
--- a/src/micropython.cmake
+++ b/src/micropython.cmake
@@ -6,15 +6,28 @@ target_sources(usermod_esp32camera INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/modcamera.c
 )
 
+set(MOD_INCLUDES ${CMAKE_CURRENT_LIST_DIR})
+
+# gets esp_lcd include paths
+idf_component_get_property(CAMERA_INCLUDES esp32-camera INCLUDE_DIRS)
+idf_component_get_property(CAMERA_PRIV_INCLUDES esp32-camera PRIV_INCLUDE_DIRS)
+
+# gets the path to the component
+idf_component_get_property(CAMERA_DIR esp32-camera COMPONENT_DIR)
+
+# sets the include paths into MOD_INCLUDES variable
+if(CAMERA_INCLUDES)
+    list(TRANSFORM CAMERA_INCLUDES PREPEND ${CAMERA_DIR}/)
+    list(APPEND MOD_INCLUDES ${CAMERA_INCLUDES})
+endif()
+
+if(CAMERA_PRIV_INCLUDES)
+    list(TRANSFORM CAMERA_PRIV_INCLUDES PREPEND ${CAMERA_DIR}/)
+    list(APPEND MOD_INCLUDES ${CAMERA_PRIV_INCLUDES})
+endif()
+
 # Add the current directory as an include directory.
-target_include_directories(usermod_esp32camera INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${IDF_PATH}/components/esp32-camera/driver/include
-    ${IDF_PATH}/components/esp32-camera/driver/private_include
-    ${IDF_PATH}/components/esp32-camera/conversions/include
-    ${IDF_PATH}/components/esp32-camera/conversions/private_include
-    ${IDF_PATH}/components/esp32-camera/sensors/private_include
-)
+target_include_directories(usermod_esp32camera INTERFACE ${MOD_INCLUDES})
 
 target_compile_definitions(usermod_esp32camera INTERFACE)
 


### PR DESCRIPTION
The way it is done now it makes no assumptions as to the location of the component. It queries the IDF build system as to its location. This allows for adding the include paths to this project.

